### PR TITLE
Reduce log rates for daemon-ocf

### DIFF
--- a/ocf/keystone
+++ b/ocf/keystone
@@ -211,7 +211,7 @@ keystone_validate() {
 keystone_status() {
     local pid
     local rc
-	 ocf_log info PID file is $OCF_RESKEY_pid 
+	 ocf_log debug PID file is $OCF_RESKEY_pid 
     if [ ! -f $OCF_RESKEY_pid ]; then
 	ocf_log info "pid file not found .."
     ocf_log info "OpenStack Identity (Keystone) is not running .."


### PR DESCRIPTION
This change will modify one info log for keystone, making it debug level.
To be able to check these logs, HA_debug=1 variable shall be added to
ocf script for this process.

Test Plan:

PASS: Verify that selected logs to be changed to debug are not logged
as info anymore
PASS: Verify after enabling debug level logs these logs are correctly
logged as debug

Failure Path:

PASS: Verify logs are not logged if variable is removed or set to 0

Regression:

PASS: Verify system install
PASS: Verify all log levels, other than debug, are still being
generated (related to task 43606)

Story: 2009272

Signed-off-by: Joao Paulo Tavares Musico <joaopaulotavares.musico@windriver.com>